### PR TITLE
chore: use https for word_tools git URL

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -742,7 +742,7 @@ packages:
       path: "."
       ref: "v0.1.0"
       resolved-ref: e712415ecea6bafe60f4b1d955a99eab12b32a59
-      url: "git@github.com:el-apps/word_tools.git"
+      url: "https://github.com/el-apps/word_tools.git"
     source: git
     version: "0.1.0+1"
   xdg_directories:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   bible_parser_flutter: ^0.1.0
   word_tools:
     git:
-      url: git@github.com:el-apps/word_tools.git
+      url: https://github.com/el-apps/word_tools.git
       ref: v0.1.0
   provider: ^6.1.5
   freezed_annotation: ^3.1.0


### PR DESCRIPTION
https://github.com/el-apps/Escritura/actions/runs/17097739796/job/48486074521 failed because it couldn't clone using ssh. Let's try https instead.